### PR TITLE
Initial REST API endpoints for repos and branches

### DIFF
--- a/ployst/repos/models.py
+++ b/ployst/repos/models.py
@@ -15,6 +15,10 @@ class Revision(models.CharField):
         kwargs['max_length'] = 40
         super(Revision, self).__init__(self, *args, **kwargs)
 
+    def __unicode__(self):
+        "The display name will be the column name"
+        return self.column
+
 add_introspection_rules([], ["^ployst\.repos\.models\.Revision"])
 
 
@@ -33,6 +37,9 @@ class Repository(models.Model):
     class Meta:
         verbose_name_plural = 'repositories'
 
+    def __unicode__(self):
+        return self.name
+
 
 class Branch(models.Model):
     """
@@ -41,9 +48,12 @@ class Branch(models.Model):
     Contains information such as its latest known revision.
 
     """
-    repo = models.ForeignKey(Repository)
+    repo = models.ForeignKey(Repository, related_name='branches')
     name = models.CharField(max_length=100)
     head = Revision(help_text="Latest known revision")
 
     class Meta:
         verbose_name_plural = 'branches'
+
+    def __unicode__(self):
+        return "{name} ({head})".format(**self.__dict__)

--- a/ployst/repos/serializers.py
+++ b/ployst/repos/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+
+from .models import Branch, Repository
+
+
+class BranchSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Branch
+        fields = ('id', 'name', 'head')
+
+
+class RepositorySerializer(serializers.ModelSerializer):
+    branches = BranchSerializer(many=True)
+
+    class Meta:
+        model = Repository
+        fields = ('id', 'name', 'branches', 'url')

--- a/ployst/repos/urls.py
+++ b/ployst/repos/urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import url, patterns, include
+
+from rest_framework import routers
+from . import views
+
+router = routers.SimpleRouter()
+router.register(r'repo', views.RepositoryViewSet)
+router.register(r'branch', views.BranchViewSet)
+
+urlpatterns = patterns(
+    '',
+    url(r'^', include(router.urls)),
+)

--- a/ployst/repos/views.py
+++ b/ployst/repos/views.py
@@ -1,3 +1,13 @@
-from django.shortcuts import render
+from rest_framework.viewsets import ModelViewSet
 
-# Create your views here.
+from .models import Repository, Branch
+from .serializers import RepositorySerializer
+
+
+class RepositoryViewSet(ModelViewSet):
+    model = Repository
+    serializer_class = RepositorySerializer
+
+
+class BranchViewSet(ModelViewSet):
+    model = Branch

--- a/ployst/settings/base.py
+++ b/ployst/settings/base.py
@@ -8,9 +8,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+PLOYST_DIR = os.path.dirname(os.path.dirname(__file__))
+ROOT_DIR = os.path.dirname(PLOYST_DIR)
 
 
 # Quick-start development settings - unsuitable for production
@@ -38,6 +38,7 @@ INSTALLED_APPS = (
 
     # 3rd party apps
     'south',
+    'rest_framework',                 # restful api
 
     # ployst proprietary apps
     'ployst.repos',
@@ -63,7 +64,7 @@ WSGI_APPLICATION = 'ployst.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(ROOT_DIR, 'db.sqlite3'),
     }
 }
 
@@ -80,3 +81,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+
+TEMPLATE_DIRS = (
+    os.path.join(PLOYST_DIR, 'templates'),
+)

--- a/ployst/urls.py
+++ b/ployst/urls.py
@@ -1,12 +1,12 @@
 from django.conf.urls import patterns, include, url
-
 from django.contrib import admin
+
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'ployst.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
+urlpatterns = patterns(
+    '',
 
     url(r'^admin/', include(admin.site.urls)),
+
+    url(r'^repos/', include('ployst.repos.urls', namespace='repos')),
 )


### PR DESCRIPTION
This sets up an initial set of ReST endpoints for repos and branches. Little work, but it is already a full-fledged API thanks to the magic of DRF. This will be the starting point for doing any initial Angular front-end.

You can browse the API (and create objects as well) at http://localhost:8000/repos/repo/

Not included in this PR are user authentication and permissions (it will be the purpose of https://txels.tpondemand.com/entity/275 and later stories, and this PR is still part of https://txels.tpondemand.com/entity/282)
