### PR TITLE
Make team property available to all TeamObject subclasses

### DIFF
--- a/ployst/core/accounts/managers.py
+++ b/ployst/core/accounts/managers.py
@@ -9,7 +9,7 @@ class TeamObjectsQuerySet(QuerySet):
 
     def for_team(self, team):
         """
-        Filtered queryset only containing objects that belong to a team
+        Filtered queryset only containing objects that belong to a team.
         """
         try:
             perm_kwargs = {self.model.team_lookup: team}
@@ -19,7 +19,7 @@ class TeamObjectsQuerySet(QuerySet):
 
     def for_user(self, user):
         """
-        Filtered queryset only containing objects that belong to a user
+        Filtered queryset only containing objects that belong to a user.
         """
         try:
             user_lookup = self.model.team_lookup + '__users'
@@ -31,22 +31,29 @@ class TeamObjectsQuerySet(QuerySet):
 
 class TeamObjectsManager(Manager):
     """
-    A Manager to access a custom QuerySet for owned objects
+    A Manager to access a custom QuerySet for owned objects.
 
     It can filter objects that belong to a team or to a user
     """
 
     def get_query_set(self):
-        return TeamObjectsQuerySet(self.model, using=self._db)
+        """
+        Return a team objects query set.
+
+        Reduce number of further DB queries for team lookups by using
+        ``select_related``.
+        """
+        qs = TeamObjectsQuerySet(self.model, using=self._db)
+        return qs.select_related(self.model.team_lookup)
 
     def for_team(self, team):
         """
-        Return only team objects
+        Return only team objects.
         """
         return self.get_query_set().for_team(team)
 
     def for_user(self, user):
         """
-        Return only user objects
+        Return only user objects.
         """
         return self.get_query_set().for_user(user)

--- a/ployst/core/accounts/models.py
+++ b/ployst/core/accounts/models.py
@@ -53,13 +53,23 @@ class TeamUser(models.Model):
 
 class TeamObject(models.Model):
     """
-    Base class for models that are objects that are owned by a team
+    Base class for models that are objects that are owned by a team.
 
+    It relies on the class having a field ``team_lookup`` that is a django
+    ORM-style lookup from object to team.
     """
     objects = TeamObjectsManager()
 
     class Meta:
         abstract = True
+
+    @property
+    def team(self):
+        team_path = self.team_lookup.split('__')
+        value = self
+        for attr in team_path:
+            value = getattr(value, attr)
+        return value.guid
 
 
 class Project(TeamObject):

--- a/ployst/core/repos/models.py
+++ b/ployst/core/repos/models.py
@@ -46,11 +46,6 @@ class Repository(TeamObject):
     def __unicode__(self):
         return self.name
 
-    @property
-    def team(self):
-        if hasattr(self.project, 'team'):
-            return self.project.team.guid
-
 
 class Branch(TeamObject):
     """


### PR DESCRIPTION
This stems from a comment I made to your PR, how it should be easy to make a `team` property available to all subclasses of `TeamObject`.
