### PR TITLE
Kick off async process on github posts. Add command for easier testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tags
 # Build byproducts
 docs/build
 /static
+ployst/settings/dev_al.py

--- a/docs/source/celery.rst
+++ b/docs/source/celery.rst
@@ -19,7 +19,7 @@ You should see log messages in the celery worker console.
 Adding celery tasks
 ===================
 
-Celery tasks are found if they are put inside a ``tasks.py`` modue
+Celery tasks are found if they are put inside a ``tasks.py`` module
 of an app that is registered in ``INSTALLED_APPS`` of settings.
 
 

--- a/docs/source/celery.rst
+++ b/docs/source/celery.rst
@@ -1,0 +1,25 @@
+Running celery worker
+=====================
+
+1. Make sure rabbitmq-server is running locally::
+
+    sudo rabbitmq-server
+
+2. Run the celery worker::
+
+    celery worker --app=ployst -l info
+
+3. To test it has worked, run the github_poke::
+
+    python manage.py github_poke http://github.com/pretenders/ployst develop
+
+You should see log messages in the celery worker console.
+
+
+Adding celery tasks
+===================
+
+Celery tasks are found if they are put inside a ``tasks.py`` modue
+of an app that is registered in ``INSTALLED_APPS`` of settings.
+
+

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,12 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ployst.settings.dev")
+    if 'test' in sys.argv:
+        settings_path = 'ployst.settings.test'
+    else:
+        settings_path = 'ployst.settings.dev'
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_path)
 
     from django.core.management import execute_from_command_line
 

--- a/ployst/__init__.py
+++ b/ployst/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .celery import app as celery_app  # NOQA

--- a/ployst/__init__.py
+++ b/ployst/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import absolute_import
-
 from .celery import app as celery_app  # NOQA

--- a/ployst/apibase/management/commands/github_poke.py
+++ b/ployst/apibase/management/commands/github_poke.py
@@ -1,4 +1,5 @@
 import json
+from optparse import make_option
 
 import requests
 
@@ -7,6 +8,13 @@ from django.core.management.base import BaseCommand, CommandError
 
 class Command(BaseCommand):
     args = '<repo_url> <branch_name>'
+    option_list = BaseCommand.option_list + (
+        make_option('-p', '--port',
+            dest="port",
+            help="port to POST to (default: 8000)",
+            default='8000'
+            ),
+        )
     help = """Create a fake message from github to force an update.
     Requires a running instance"""
 
@@ -16,8 +24,9 @@ class Command(BaseCommand):
                 self.args, len(args)))
 
         repo_url, branch_name = args
-
-        url = 'http://localhost:8000/providers/github/receive-hook/tOkEn/'
+        port = options.get('port')
+        url = ('http://localhost:{port}/'
+               'providers/github/receive-hook/tOkEn/'.format(port=port))
         load = json.dumps({
             'repository': {
                 'url': repo_url

--- a/ployst/apibase/management/commands/github_poke.py
+++ b/ployst/apibase/management/commands/github_poke.py
@@ -1,0 +1,31 @@
+import json
+
+import requests
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    args = '<repo_url> <branch_name>'
+    help = """Create a fake message from github to force an update.
+    Requires a running instance"""
+
+    def handle(self, *args, **options):
+        if len(args) != 2:
+            raise CommandError("Expecting 2 arguments: {}. Got {}".format(
+                self.args, len(args)))
+
+        repo_url, branch_name = args
+
+        url = 'http://localhost:8000/providers/github/receive-hook/tOkEn/'
+        load = json.dumps({
+            'repository': {
+                'url': repo_url
+            },
+            'ref': branch_name
+        })
+        response = requests.post(url, data={'payload': load})
+        print response.status_code
+        if response.status_code != 200:
+            with file('/tmp/error.html', 'w') as f:
+                f.write(response.content)

--- a/ployst/celery.py
+++ b/ployst/celery.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+import os
+
+from celery import Celery
+
+from django.conf import settings
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ployst.settings.dev')
+
+app = Celery('ployst')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/ployst/github/lib.py
+++ b/ployst/github/lib.py
@@ -54,8 +54,10 @@ class HierarchyHandler(object):
         statuses = []
         for node in all_nodes:
             parent_name = node.parent.branch if node.parent else None
-            merged_into_parent = self.git.is_contained(
-                node.commit, parent_name)
+            merged_into_parent = False
+            if parent_name:
+                merged_into_parent = self.git.is_contained(
+                    node.commit, parent_name)
 
             statuses.append({
                 'head': node.commit,

--- a/ployst/github/management/commands/github_poke.py
+++ b/ployst/github/management/commands/github_poke.py
@@ -4,17 +4,18 @@ from optparse import make_option
 import requests
 
 from django.core.management.base import BaseCommand, CommandError
+from django.core.urlresolvers import reverse
 
 
 class Command(BaseCommand):
     args = '<repo_url> <branch_name>'
     option_list = BaseCommand.option_list + (
         make_option('-p', '--port',
-            dest="port",
-            help="port to POST to (default: 8000)",
-            default='8000'
-            ),
-        )
+                    dest="port",
+                    help="port to POST to (default: 8000)",
+                    default='8000'
+                    ),
+    )
     help = """Create a fake message from github to force an update.
     Requires a running instance"""
 
@@ -25,15 +26,16 @@ class Command(BaseCommand):
 
         repo_url, branch_name = args
         port = options.get('port')
-        url = ('http://localhost:{port}/'
-               'providers/github/receive-hook/tOkEn/'.format(port=port))
+        url = reverse('github:hook', kwargs={'hook_token': "tOkEn"})
+        full_url = 'http://localhost:{port}{url}'.format(url=url, port=port)
+
         load = json.dumps({
             'repository': {
                 'url': repo_url
             },
             'ref': branch_name
         })
-        response = requests.post(url, data={'payload': load})
+        response = requests.post(full_url, data={'payload': load})
         print response.status_code
         if response.status_code != 200:
             with file('/tmp/error.html', 'w') as f:

--- a/ployst/github/tasks.py
+++ b/ployst/github/tasks.py
@@ -1,0 +1,87 @@
+from ployst.celery import app
+from ployst.core.client import Client
+
+from .conf import settings
+from .lib import match_features, HierarchyHandler
+
+client = Client('http://localhost:8000/', settings.GITHUB_HOOK_TOKEN)
+
+
+@app.task
+def recalculate(repo_url, branch_name):
+    """
+    Recalculate all relevant branch information given a new commit
+
+    Encapsulated in this function:
+
+    The full update given a repo is:
+        - Get all repos that match the repo url
+        - Get all features that belong to projects that use these repos.
+        - For all features, see if it matches the branch given.
+        - If there is a matching feature, get all branches that match that
+          feature.
+        - For all branches, ask the following:
+            - Are they merged into their parent?
+            - What is the current HEAD
+            - Which feature they relate to?
+        - Update the branch info.
+
+    End goal is that we have enough data at the front end to generate a picture
+    of the following
+
+    - feature branch
+        - dev branch (merged in)
+        - dev branch 2 (not merged in)
+    """
+    repos = client.get_repos_by_url(repo_url)
+    for repo in repos:
+
+        # TODO: Implement settings. Model and API calls.
+        prov_settings = client.get_provider_settings(
+            repo.project,
+            settings.GITHUB_NAME
+        )
+        regexes = prov_settings['branch_finders']
+
+        features = client.get_features_by_project(repo['project'])
+
+        matched_features = match_features(
+            features,
+            regexes,
+            branch_name,
+        )
+
+        if not matched_features:
+            continue
+
+        controller = HierarchyHandler(path=repo['local_path'])
+
+        for feature in matched_features:
+            hierarchy = controller.get_branch_hierarchy(
+                feature['feature_id'],
+                regexes
+            )
+            statuses = controller.get_branch_merge_statuses(
+                hierarchy, branch_name
+            )
+            save_branch_statuses(statuses, repo['id'], feature['id'])
+
+
+def save_branch_statuses(statuses, repo_id, feature_id):
+    for branch_status in statuses:
+        parent = None
+        if branch_status['parent_name']:
+            parent = client.get_branch_by_name(
+                repo=repo_id,
+                name=branch_status['parent_name'])
+
+        parent_id = parent['id'] if parent else None
+
+        client.create_or_update_branch_information({
+            'repo': repo_id,
+            'name': branch_status['branch_name'],
+            'head': branch_status['head'],
+            'merged_into_parent': branch_status['merged_into_parent'],
+            'parent': parent_id,
+            'feature': feature_id,
+        })

--- a/ployst/github/tasks.py
+++ b/ployst/github/tasks.py
@@ -74,8 +74,7 @@ def save_branch_statuses(statuses, repo_id, feature_id):
             parent = client.get_branch_by_name(
                 repo=repo_id,
                 name=branch_status['parent_name'])
-
-        parent_id = parent['id'] if parent else None
+        parent_id = parent[0]['id'] if parent else None
 
         client.create_or_update_branch_information({
             'repo': repo_id,

--- a/ployst/github/test/test_end_to_end.py
+++ b/ployst/github/test/test_end_to_end.py
@@ -1,10 +1,11 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+
 from mock import patch, Mock
 from supermutes.dot import dotify
 
 from . import read_data, DUMMY_REPO, ensure_dummy_clone_available
-from .. import views  # noqa
+from .. import tasks  # noqa
 
 
 class MockClient(object):
@@ -61,7 +62,7 @@ class TestEndToEnd(TestCase):
     def setUp(self):
         ensure_dummy_clone_available()
 
-    @patch(__name__ + '.views.client', MockClient())
+    @patch(__name__ + '.tasks.client', MockClient())
     def test_receive_hook_end_to_end(self):
         """
         Perform a full end to end test with the receive hook.
@@ -69,7 +70,7 @@ class TestEndToEnd(TestCase):
         A github-like POST to the receive hook should result in branch(es)
         being updated in core.
         """
-        from ..views import client as core_client
+        from ..tasks import client as core_client
 
         data = read_data('end-to-end.json')
 

--- a/ployst/github/test/test_end_to_end.py
+++ b/ployst/github/test/test_end_to_end.py
@@ -33,10 +33,10 @@ class MockClient(object):
         }
 
     def get_branch_by_name(self, repo, name):
-        return {
+        return [{
             'name': name,
             'id': 1001
-        }
+        }]
 
     def get_features_by_project(self, project_id):
         return [

--- a/ployst/github/test/test_receive_hook.py
+++ b/ployst/github/test/test_receive_hook.py
@@ -28,9 +28,9 @@ class TestReceiveHook(TestCase):
         response = self.post({'payload': data})
 
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(recalculate.call_count, 1)
+        self.assertEquals(recalculate.delay.call_count, 1)
         self.assertEquals(
-            recalculate.call_args[0],
+            recalculate.delay.call_args[0],
             ('https://github.com/pretenders/ployst',
              'dev_alex'))
 

--- a/ployst/github/views.py
+++ b/ployst/github/views.py
@@ -25,5 +25,6 @@ def receive_hook(request, hook_token):
         LOGGER.error('Unexpected data structure: {0}'.format(request.POST))
         return HttpResponseBadRequest()
 
-    recalculate.delay(url, branch_name)
+    f = recalculate.delay(url, branch_name)
+    print f
     return HttpResponse("OK")

--- a/ployst/github/views.py
+++ b/ployst/github/views.py
@@ -7,92 +7,9 @@ from django.http import (
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 
-from ployst.core.client import Client
-from .conf import settings
-from .lib import match_features, HierarchyHandler
+from .tasks import recalculate
 
 LOGGER = logging.getLogger(__name__)
-
-client = Client('http://localhost:8000/', settings.GITHUB_HOOK_TOKEN)
-
-
-def recalculate(repo_url, branch_name):
-    """
-    Recalculate all relevant branch information given a new commit
-
-    Encapsulated in this function:
-
-    The full update given a repo is:
-        - Get all repos that match the repo url
-        - Get all features that belong to projects that use these repos.
-        - For all features, see if it matches the branch given.
-        - If there is a matching feature, get all branches that match that
-          feature.
-        - For all branches, ask the following:
-            - Are they merged into their parent?
-            - What is the current HEAD
-            - Which feature they relate to?
-        - Update the branch info.
-
-    End goal is that we have enough data at the front end to generate a picture
-    of the following
-
-    - feature branch
-        - dev branch (merged in)
-        - dev branch 2 (not merged in)
-    """
-    repos = client.get_repos_by_url(repo_url)
-    for repo in repos:
-
-        #TODO: Implement settings. Model and API calls.
-        prov_settings = client.get_provider_settings(
-            repo.project,
-            settings.GITHUB_NAME
-        )
-        regexes = prov_settings['branch_finders']
-
-        features = client.get_features_by_project(repo['project'])
-
-        matched_features = match_features(
-            features,
-            regexes,
-            branch_name,
-        )
-
-        if not matched_features:
-            continue
-
-        controller = HierarchyHandler(path=repo['local_path'])
-
-        for feature in matched_features:
-            hierarchy = controller.get_branch_hierarchy(
-                feature['feature_id'],
-                regexes
-            )
-            statuses = controller.get_branch_merge_statuses(
-                hierarchy, branch_name
-            )
-            save_branch_statuses(statuses, repo['id'], feature['id'])
-
-
-def save_branch_statuses(statuses, repo_id, feature_id):
-    for branch_status in statuses:
-        parent = None
-        if branch_status['parent_name']:
-            parent = client.get_branch_by_name(
-                repo=repo_id,
-                name=branch_status['parent_name'])
-
-        parent_id = parent['id'] if parent else None
-
-        client.create_or_update_branch_information({
-            'repo': repo_id,
-            'name': branch_status['branch_name'],
-            'head': branch_status['head'],
-            'merged_into_parent': branch_status['merged_into_parent'],
-            'parent': parent_id,
-            'feature': feature_id,
-        })
 
 
 @csrf_exempt
@@ -108,6 +25,5 @@ def receive_hook(request, hook_token):
         LOGGER.error('Unexpected data structure: {0}'.format(request.POST))
         return HttpResponseBadRequest()
 
-    # TODO: Make this an async task.
-    recalculate(url, branch_name)
+    recalculate.delay(url, branch_name)
     return HttpResponse("OK")

--- a/ployst/settings/base.py
+++ b/ployst/settings/base.py
@@ -51,6 +51,9 @@ INSTALLED_APPS = (
     'ployst.core.repos',            # version control: repos, branches...
     'ployst.core.builds',           # continuous integration: build results...
     'ployst.ui',                    # The main Ployst UI
+
+    # Providers
+    'ployst.github'
 )
 
 MIDDLEWARE_CLASSES = (

--- a/ployst/settings/dev.py
+++ b/ployst/settings/dev.py
@@ -3,4 +3,3 @@ from .base import *  # noqa
 
 DEBUG = True
 TEMPLATE_DEBUG = True
-

--- a/ployst/settings/dev.py
+++ b/ployst/settings/dev.py
@@ -4,4 +4,3 @@ from .base import *  # noqa
 DEBUG = True
 TEMPLATE_DEBUG = True
 
-GITHUB_HOOK_TOKEN = "ba6d427e-a893-4014-9633-e38c55210b52"

--- a/ployst/settings/test.py
+++ b/ployst/settings/test.py
@@ -1,0 +1,3 @@
+from .dev import *  # NOQA
+
+CELERY_ALWAYS_EAGER = True

--- a/ployst/settings/test.py
+++ b/ployst/settings/test.py
@@ -1,3 +1,4 @@
 from .dev import *  # NOQA
 
 CELERY_ALWAYS_EAGER = True
+CELERY_EAGER_PROPAGATES_EXCEPTIONS = True

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -14,3 +14,5 @@ apitopy==0.3.0
 
 # Git provider requirements
 GitPython==0.3.2.RC1             # access git repositories
+
+celery==3.1.9


### PR DESCRIPTION
This PR contains some controversial elements.

The main two being:
- the decision to make celery a system wide runner and not just nestled inside the github package.
- the addition of github as a django `INSTALLED_APP`

I began by writing a celery app just within the github app, but decided that it made more sense for the github app to define the tasks it needs, but not be responsible for running celery itself.

Additionally, if settings is just seen as the final configuration layer when setting up ployst, and it can contain settings like `GITHUB_HOOK_TOKEN`, then it makes sense for github to be an app listed in `INSTALLED_APPS`. (And this had the benefit of making it exceptionally easy to use a centralized celery app).

I think that we should, however, continue to develop against the RESTful API - despite the fact that performance wise it makes more sense for the client to be using django models directly. The reason being it will force us to make the API robust and this will certainly be useful when extending the angular client.
