### PR TITLE
dj_static is not a requirement for local development

### DIFF
--- a/ployst/wsgi.py
+++ b/ployst/wsgi.py
@@ -8,11 +8,11 @@ https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
 
 import os
+from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", 'ployst.settings.dev')
+application = get_wsgi_application()
 
-from django.core.wsgi import get_wsgi_application
-from dj_static import Cling
-
-
-application = Cling(get_wsgi_application())
+if 'ON_HEROKU' in os.environ:
+    from dj_static import Cling
+    application = Cling(application)


### PR DESCRIPTION
After the changes done for heroku, the local development environment was broken, i.e. even after running `fab develop`, `./manage.py runserver` failed. 

As `dj_static` is only a requirement for heroku, I've made sure `wsgi.py` is still usable outside heroku.
