### PR TITLE
Redirect to the correct location after oauth.

### DIFF
--- a/ployst/github/test/test_oauth.py
+++ b/ployst/github/test/test_oauth.py
@@ -47,7 +47,7 @@ class TestOAuthBehaviour(TestCase):
 
         self.assertEquals(response.status_code, 302)
         self.assertEquals(response['Location'],
-                          'http://testserver/ui/#/providers/github')
+                          'http://testserver/ui/#/projects')
         self.assertEquals(oauth_exchange.call_count, 1)
         self.assertEquals(oauth_exchange.call_args[0],
                           (None, 'secret_github_code',))

--- a/ployst/github/views/oauth.py
+++ b/ployst/github/views/oauth.py
@@ -44,7 +44,7 @@ def receive(request):
             request.GET['state'] != settings.GITHUB_OAUTH_STATE):
         return HttpResponseBadRequest()
     exchange_for_access_token(request.user.id, request.GET['code'])
-    github_provider_url = reverse('ui:home') + '#/providers/github'
+    github_provider_url = reverse('ui:home') + '#/projects'
     return HttpResponseRedirect(github_provider_url)
 
 


### PR DESCRIPTION
This is a quick fix for an issue I saw that was after you oauth you were redirected to a different page than where the button was pressed.

This is a quick fix in the sense that it hard codes where you end up - if we want more places to enable oauth we will need to pass additional params to github that we can use when it comes back.
