### PR TITLE
Add visual cues to which repos are tracked by a project

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,7 @@ module.exports = function(config) {
 
             'ployst/**/static/app.js',
             'ployst/**/static/**/ployst.*.js',
+            'ployst/github/static/github/github-app.js',
             'ployst/**/static/test/**.js',
         ],
 

--- a/ployst/github/static/github/github-app.js
+++ b/ployst/github/static/github/github-app.js
@@ -1,6 +1,8 @@
 (function() {
 
-    angular.module('ployst')
+    angular.module('ployst.github', [
+            'ployst.repos'
+        ])
         .factory('github.Organisations', [
             '$resource',
             function($resource) {
@@ -31,21 +33,49 @@
         ])
         .controller('github', [
             '$scope', 'github.Token', 'github.Organisations',
-            'github.OrgRepos', 'github.Repos',
-            function($scope, GHToken, GHOrganisations, GHOrgRepos, GHRepos) {
+            'github.OrgRepos', 'github.Repos', 'Repos',
+
+            function($scope, GHToken, GHOrganisations, GHOrgRepos, GHRepos, Repos)
+            {
+
+                var repoCount = {},
+                    trackedRepos = {};
 
                 $scope.hasToken = null;
                 $scope.repos = null;
                 $scope.organisations = null;
+                $scope.selectedOrganisation = null;
+                $scope.myGithubLogin = null;
 
                 var loadData = function() {
-                    GHOrganisations.query(function(orgs) {
-                        $scope.organisations = orgs;
-                        $scope.selectedOrganisation = orgs[0];
+                    Repos.query({project: $scope.projectId}, function(repos) {
+                        angular.forEach(repos, function(repo) {
+                            repoCount[repo.owner] = (repoCount[repo.owner] || 0) + 1;
+                            trackedRepos[repo.owner + '/' + repo.name] = true;
+                        });
+
+                        GHOrganisations.query(function(orgs) {
+                            $scope.organisations = orgs;
+                            // we rely on the backend API giving us the user's
+                            // personal account as the first organisation:
+                            $scope.myGithubLogin = orgs[0].login;
+                            angular.forEach(orgs, function(org) {
+                                org.trackedRepos = repoCount[org.login];
+                            });
+
+                            $scope.selectOrganisation(orgs[0]);
+                        });
                     });
-                    GHRepos.query(function(repos) {
-                        $scope.repos = repos;
+                };
+
+
+                var incorporateRepos = function(repos) {
+                    var owner = $scope.selectedOrganisation.login;
+                    $scope.repos = repos;
+                    angular.forEach(repos, function(repo) {
+                        repo.tracked = trackedRepos[owner + '/' + repo.name] || false;
                     });
+
                 };
 
                 $scope.selectOrganisation = function(org) {
@@ -54,15 +84,14 @@
 
                     if (org.type === 'User') {
                         GHRepos.query(function(repos) {
-                            $scope.repos = repos;
+                            incorporateRepos(repos);
                         });
                     } else {
-                        GHOrgRepos.query({
-                            id: org.login
-                        }, function(repos) {
-                            $scope.repos = repos;
+                        GHOrgRepos.query({id: org.login}, function (repos) {
+                            incorporateRepos(repos);
                         });
                     }
+
                 };
 
                 GHToken.query(function(token) {
@@ -79,7 +108,10 @@
             return {
                 controller: 'github',
                 restrict: 'E',
-                templateUrl: STATIC_URL + 'github/config.html'
+                templateUrl: STATIC_URL + 'github/github-config.html',
+                scope: {
+                    projectId: '='
+                }
             };
         });
 })();

--- a/ployst/github/static/github/github-config.html
+++ b/ployst/github/static/github/github-config.html
@@ -17,7 +17,9 @@
             <li ng-repeat="org in organisations"
                 ng-class="{'list-group-item-warning': org===selectedOrganisation}"
                 ng-click="selectOrganisation(org)">
-                <img ng-src="{{ org.avatar_url }}" width=24 height=24> {{ org.login }}
+                <img ng-src="{{ org.avatar_url }}" width=24 height=24>
+                {{ org.login }}
+                <span class="pull-right badge">{{ org.trackedRepos }}</span>
             </li>
         </ul>
     </div>
@@ -31,7 +33,8 @@
                 <i ng-if="repo.fork" class="fa fa-fw fa-code-fork"></i>
                 <span class="pull-right">
                     <a class="hover-options" href="{{ repo.html_url }}" target="_blank"><i class="fa fa-fw fa-github-alt"></i> github</a>
-                    <a><i class="fa fa-fw fa-folder"></i> import</a>
+                    <a ng-if="repo.tracked"><i class="fa fa-fw fa-check"></i></a>
+                    <a ng-if="!repo.tracked" class="hover-options"><i class="fa fa-fw fa-plus"></i></a>
                 </span>
             </li>
         </ul>

--- a/ployst/ui/static/app.js
+++ b/ployst/ui/static/app.js
@@ -11,7 +11,10 @@ var ployst = angular.module('ployst', [
 
         'ployst.profile',
         'ployst.projects',
-        'ployst.providers'
+        'ployst.providers',
+        'ployst.repos',
+
+        'ployst.github'
     ])
     .run([
         '$http', '$cookies',

--- a/ployst/ui/static/projects/ployst.projects.js
+++ b/ployst/ui/static/projects/ployst.projects.js
@@ -2,7 +2,7 @@
  * Ployst project management page
  */
 angular.module('ployst.projects', [
-        'ngResource',
+        'ngResource'
     ])
     .factory('Project', [
         '$resource',

--- a/ployst/ui/static/projects/projects.html
+++ b/ployst/ui/static/projects/projects.html
@@ -17,7 +17,7 @@
                 <project-users></project-users>
             </div>
             <div class="row-fluid">
-                <github-config></github-config>
+                <github-config project-id="project.id"></github-config>
             </div>
         </div>
     </div>

--- a/ployst/ui/static/repos/ployst.repos-test.js
+++ b/ployst/ui/static/repos/ployst.repos-test.js
@@ -1,0 +1,35 @@
+describe('test repos', function() {
+
+    var ctrl,
+        scope,
+        mockUser = {
+            username: 'me',
+            id: 1
+        },
+        mockRepo = {
+            'id': 1,
+            'name': 'ployst',
+            'owner': 'pretenders',
+            'branches': [],
+            'project': 1
+        },
+        mockRepos = [mockRepo],
+        _Repo;
+
+    beforeEach(module('ployst.repos'));
+
+    beforeEach(inject(function(_$httpBackend_, RepoService) {
+        $httpBackend = _$httpBackend_;
+        _RepoService = RepoService;
+    }));
+
+    it('getRepos gives a list of repos for a project', function() {
+        $httpBackend.expectGET('/core/repos/repo?project=1')
+            .respond(mockRepos);
+        repos = _RepoService.getRepos(1);
+        $httpBackend.flush();
+        expect(repos.length).toBe(1);
+        expect(repos[0].name).toBe('ployst');
+    });
+
+});

--- a/ployst/ui/static/repos/ployst.repos.js
+++ b/ployst/ui/static/repos/ployst.repos.js
@@ -1,0 +1,22 @@
+/**
+ * Ployst project management page
+ */
+angular.module('ployst.repos', [
+        'ngResource'
+    ])
+    .factory('Repos', [
+        '$resource',
+
+        function($resource) {
+            return $resource('/core/repos/repo');
+        }
+    ])
+    .service('RepoService', [
+        'Repos',
+
+        function(Repos) {
+            this.getRepos = function(projectId) {
+                return Repos.query({project: projectId});
+            };
+        }
+    ]);

--- a/ployst/ui/templates/ui/admin.html
+++ b/ployst/ui/templates/ui/admin.html
@@ -13,7 +13,6 @@
 <script src="{{ STATIC_URL }}profile/ployst.profile.js"></script>
 <script src="{{ STATIC_URL }}projects/ployst.projects.js"></script>
 <script src="{{ STATIC_URL }}providers/ployst.providers.js"></script>
-{% for provider in providers %}
-    <script src="{{ STATIC_URL }}{{ provider.slug }}/{{ provider.slug }}-app.js"></script>
-{% endfor %}
+<script src="{{ STATIC_URL }}repos/ployst.repos.js"></script>
+<script src="{{ STATIC_URL }}github/github-app.js"></script>
 {% endblock %}


### PR DESCRIPTION
This now shows a badge next to each organisation as to how many are tracked in the project, plus it replaces the "Import" link & icon with an indication whether a project is tracked or not.

In order to test you will need to add repos to projects via the admin for now.
