### PR TITLE
Tweaks to make the GH hook work against the core repo API

### DIFF
--- a/ployst/core/repos/test/test_api.py
+++ b/ployst/core/repos/test/test_api.py
@@ -29,6 +29,26 @@ class TestFiltering(ProjectTestMixin, APITestCase):
         self.assertEquals(len(repos), 1)
         self.assertEquals(repos[0]['name'], repo1.name)
 
+    def test_get_repos_by_owner_and_name(self):
+        """
+        Search by owner and name to get a list of matching repos.
+
+        This endpoint is used by the github hook. Do not remove this test
+        unless the hook no longer uses this.
+        """
+        repo1 = RepositoryFactory(owner='me', name='A', project=self.project)
+        RepositoryFactory(owner='you', name='B', project=self.project)
+        url = reverse('core:repos:repository-list')
+
+        response = self.client.get('{0}?owner={1}&name={2}'.format(
+            url, repo1.owner, repo1.name))
+
+        repos = json.loads(response.content)
+        self.assertEquals(len(repos), 1)
+        self.assertEquals(repos[0]['id'], repo1.id)
+        self.assertEquals(repos[0]['name'], repo1.name)
+        self.assertEquals(repos[0]['owner'], repo1.owner)
+
     def test_only_see_repos_for_my_projects(self):
         """
         Should not be able to see all repos.

--- a/ployst/core/repos/views.py
+++ b/ployst/core/repos/views.py
@@ -9,7 +9,7 @@ from .serializers import RepositorySerializer
 class RepositoryViewSet(PermissionsViewSetMixin, ModelViewSet):
     model = Repository
     serializer_class = RepositorySerializer
-    filter_fields = ('project',)
+    filter_fields = ('project', 'owner', 'name')
 
     def create(self, request, *args, **kwargs):
         """

--- a/ployst/github/tasks/hierarchy.py
+++ b/ployst/github/tasks/hierarchy.py
@@ -8,7 +8,7 @@ from ..path import get_destination
 
 
 @app.task
-def recalculate(repo_url, branch_name):
+def recalculate(org, repo, branch_name):
     """
     Recalculate all relevant branch information given a new commit
 
@@ -33,7 +33,7 @@ def recalculate(repo_url, branch_name):
         - dev branch (merged in)
         - dev branch 2 (not merged in)
     """
-    repos = client.get_repos(url=repo_url)
+    repos = client.get_repos(owner=org, name=repo)
     for repo in repos:
 
         prov_settings = client.get_provider_settings(

--- a/ployst/github/test/__init__.py
+++ b/ployst/github/test/__init__.py
@@ -80,7 +80,7 @@ def ensure_dummy_clone_available():
         os.system('git clone git://github.com/pretenders/dummyrepo.git {0}'
                   .format(DUMMY_REPO))
     else:
-        cmd = 'git --git-dir="{0}/.git" fetch'.format(DUMMY_REPO)
+        cmd = 'git --git-dir="{0}/.git" fetch -p'.format(DUMMY_REPO)
         ans = os.system(cmd)
         if ans != 0:
             raise Exception("Git fetch failed")

--- a/ployst/github/test/test_receive_hook.py
+++ b/ployst/github/test/test_receive_hook.py
@@ -32,8 +32,7 @@ class TestReceiveHook(TestCase):
         self.assertEquals(recalculate.delay.call_count, 1)
         self.assertEquals(
             recalculate.delay.call_args[0],
-            ('https://github.com/pretenders/ployst',
-             'dev_alex'))
+            ('pretenders', 'ployst', 'dev_alex'))
 
     def test_get_rejected(self):
         "GET requests to the receive hook end point are rejected"

--- a/ployst/github/views/hook.py
+++ b/ployst/github/views/hook.py
@@ -37,7 +37,7 @@ def receive(request):
         return HttpResponseBadRequest()
 
     if branch_name:
-        recalculate.delay(url, branch_name)
+        recalculate.delay(org, repo, branch_name)
 
     return HttpResponse("OK")
 


### PR DESCRIPTION
I believe this got lost in the models refactor where we minimised some models and got rid of teams.
I added a docstring to the test to track why it's there.
