### PR TITLE
Get head revision of a branch on github hook

### DIFF
--- a/ployst/github/tasks/hierarchy.py
+++ b/ployst/github/tasks/hierarchy.py
@@ -68,7 +68,7 @@ def recalculate(org, repo, branch_name):
 
 
 @app.task
-def update_branch_information(org, repo, branch_name):
+def update_branch_information(org, repo, branch_name, head):
     """
     Update the given branch information.
 
@@ -79,6 +79,7 @@ def update_branch_information(org, repo, branch_name):
         client.create_or_update_branch_information({
             'repo': repo['id'],
             'name': branch_name,
+            'head': head,
         })
 
 

--- a/ployst/github/test/test_receive_hook.py
+++ b/ployst/github/test/test_receive_hook.py
@@ -53,7 +53,7 @@ class TestReceiveHook(TestCase):
         self.assertEquals(update.delay.call_count, 1)
         self.assertEquals(
             update.delay.call_args[0],
-            ('pretenders', 'ployst', 'dev_alex')
+            ('pretenders', 'ployst', 'dev_alex', '0458a0f')
         )
 
     def test_get_rejected(self):


### PR DESCRIPTION
Updates #84
Turns out we can easily get commit ID from the web hook.
