### PR TITLE
Move code from projects controller into projects service

### DIFF
--- a/ployst/github/static/github/github-app.js
+++ b/ployst/github/static/github/github-app.js
@@ -1,153 +1,150 @@
-(function() {
-
-    angular.module('ployst.github', [
-            'ployst.repos'
-        ])
-        .factory('github.Organisations', [
-            '$resource',
-            function($resource) {
-                return $resource('/github/user-orgs');
-            }
-        ])
-        .factory('github.Repos', [
-            '$resource',
-            function($resource) {
-                return $resource('/github/user-repos');
-            }
-        ])
-        .factory('github.OrgRepos', [
-            '$resource',
-            function($resource) {
-                return $resource(
-                    '/github/org-repos/:id', {
-                        id: '@id'
-                    }
-                );
-            }
-        ])
-        .factory('github.Token', [
-            '$resource',
-            function($resource) {
-                return $resource('/github/oauth-access-token');
-            }
-        ])
-        .controller('GithubController', [
-            '$scope', 'github.Token', 'github.Organisations',
-            'github.OrgRepos', 'github.Repos', 'Repos',
-
-            function($scope, GHToken, GHOrganisations, GHOrgRepos, GHRepos, Repos)
-            {
-
-                var repoCount = {},      // map owner to number of tracked repos
-                    trackedRepos = {};   // map "<owner>/<repo>" to bool for fast lookup
-
-                $scope.hasToken = null;
-                $scope.repos = null;
-                $scope.organisations = null;
-                $scope.selectedOrganisation = null;
-                $scope.myGithubLogin = null;
-
-                var loadData = function() {
-                    Repos.query({project: $scope.project.id}, function(projectRepos) {
-                        GHOrganisations.query(function(orgs) {
-                            $scope.organisations = orgs;
-                            // we rely on the backend API giving us the user's
-                            // personal account as the first organisation:
-                            $scope.myGithubLogin = orgs[0].login;
-                            collectStats(projectRepos);
-
-                            $scope.selectOrganisation(orgs[0]);
-                        });
-                    });
-                };
-
-                var k = function(owner, name) {
-                    return owner + '/' + name;
-                };
-
-                var collectStats = function(projectRepos) {
-                    repoCount = {};
-                    trackedRepos = {};
-                    angular.forEach(projectRepos, function(repo) {
-                        repoCount[repo.owner] = (repoCount[repo.owner] || 0) + 1;
-                        trackedRepos[k(repo.owner, repo.name)] = repo.id;
-                    });
-                    angular.forEach($scope.organisations, function(org) {
-                        org.trackedRepos = repoCount[org.login];
-                    });
-                };
-
-                var processRepos = function(repos) {
-                    var owner = $scope.selectedOrganisation.login;
-                    $scope.repos = repos;
-                    angular.forEach(repos, function(repo) {
-                        repo.tracked = trackedRepos[k(owner, repo.name)] || false;
-                    });
-
-                };
-
-                $scope.selectOrganisation = function(org) {
-                    $scope.selectedOrganisation = org;
-                    $scope.repos = null;
-
-                    if (org.type === 'User') {
-                        GHRepos.query(function(repos) {
-                            processRepos(repos);
-                        });
-                    } else {
-                        GHOrgRepos.query({id: org.login}, function (repos) {
-                            processRepos(repos);
-                        });
-                    }
-
-                };
-
-                $scope.trackRepo = function(repo) {
-                    var projectRepo = new Repos({
-                        name: repo.name,
-                        owner: $scope.selectedOrganisation.login,
-                        project: $scope.project.id
-                    });
-                    projectRepo.$save(function(projectRepo) {
-                        repo.tracked = projectRepo.id;
-                        $scope.selectedOrganisation.trackedRepos =
-                            ($scope.selectedOrganisation.trackedRepos || 0) + 1;
-                    });
-                };
-
-                $scope.untrackRepo = function(repo) {
-                    Repos.delete({id: repo.tracked}, function() {
-                        repo.tracked = false;
-                        $scope.selectedOrganisation.trackedRepos =
-                            ($scope.selectedOrganisation.trackedRepos || 0) - 1;
-                    });
-                };
-
-                GHToken.query(function(token) {
-                    if (token.length > 0) {
-                        loadData();
-                        $scope.hasToken = true;
-                    } else {
-                        $scope.hasToken = false;
-                    }
-                });
-
-                // ensure that when current project ID changes, we reload
-                $scope.$watch(function() {
-                    return $scope.project.id;
-                }, function () {
-                    loadData();
-                });
-            }
-        ])
-        .directive('githubConfig', function() {
-            return {
-                controller: 'GithubController',
-                restrict: 'E',
-                templateUrl: STATIC_URL + 'github/github-config.html',
-                scope: {
-                    project: '='
+angular.module('ployst.github', [
+        'ployst.repos'
+    ])
+    .factory('github.Organisations', [
+        '$resource',
+        function($resource) {
+            return $resource('/github/user-orgs');
+        }
+    ])
+    .factory('github.Repos', [
+        '$resource',
+        function($resource) {
+            return $resource('/github/user-repos');
+        }
+    ])
+    .factory('github.OrgRepos', [
+        '$resource',
+        function($resource) {
+            return $resource(
+                '/github/org-repos/:id', {
+                    id: '@id'
                 }
+            );
+        }
+    ])
+    .factory('github.Token', [
+        '$resource',
+        function($resource) {
+            return $resource('/github/oauth-access-token');
+        }
+    ])
+    .controller('GithubController', [
+        '$scope', 'github.Token', 'github.Organisations',
+        'github.OrgRepos', 'github.Repos', 'Repos',
+
+        function($scope, GHToken, GHOrganisations, GHOrgRepos, GHRepos, Repos)
+        {
+
+            var repoCount = {},      // map owner to number of tracked repos
+                trackedRepos = {};   // map "<owner>/<repo>" to bool for fast lookup
+
+            $scope.hasToken = null;
+            $scope.repos = null;
+            $scope.organisations = null;
+            $scope.selectedOrganisation = null;
+            $scope.myGithubLogin = null;
+
+            var loadData = function() {
+                Repos.query({project: $scope.project.id}, function(projectRepos) {
+                    GHOrganisations.query(function(orgs) {
+                        $scope.organisations = orgs;
+                        // we rely on the backend API giving us the user's
+                        // personal account as the first organisation:
+                        $scope.myGithubLogin = orgs[0].login;
+                        collectStats(projectRepos);
+
+                        $scope.selectOrganisation(orgs[0]);
+                    });
+                });
             };
-        });
-})();
+
+            var k = function(owner, name) {
+                return owner + '/' + name;
+            };
+
+            var collectStats = function(projectRepos) {
+                repoCount = {};
+                trackedRepos = {};
+                angular.forEach(projectRepos, function(repo) {
+                    repoCount[repo.owner] = (repoCount[repo.owner] || 0) + 1;
+                    trackedRepos[k(repo.owner, repo.name)] = repo.id;
+                });
+                angular.forEach($scope.organisations, function(org) {
+                    org.trackedRepos = repoCount[org.login];
+                });
+            };
+
+            var processRepos = function(repos) {
+                var owner = $scope.selectedOrganisation.login;
+                $scope.repos = repos;
+                angular.forEach(repos, function(repo) {
+                    repo.tracked = trackedRepos[k(owner, repo.name)] || false;
+                });
+
+            };
+
+            $scope.selectOrganisation = function(org) {
+                $scope.selectedOrganisation = org;
+                $scope.repos = null;
+
+                if (org.type === 'User') {
+                    GHRepos.query(function(repos) {
+                        processRepos(repos);
+                    });
+                } else {
+                    GHOrgRepos.query({id: org.login}, function (repos) {
+                        processRepos(repos);
+                    });
+                }
+
+            };
+
+            $scope.trackRepo = function(repo) {
+                var projectRepo = new Repos({
+                    name: repo.name,
+                    owner: $scope.selectedOrganisation.login,
+                    project: $scope.project.id
+                });
+                projectRepo.$save(function(projectRepo) {
+                    repo.tracked = projectRepo.id;
+                    $scope.selectedOrganisation.trackedRepos =
+                        ($scope.selectedOrganisation.trackedRepos || 0) + 1;
+                });
+            };
+
+            $scope.untrackRepo = function(repo) {
+                Repos.delete({id: repo.tracked}, function() {
+                    repo.tracked = false;
+                    $scope.selectedOrganisation.trackedRepos =
+                        ($scope.selectedOrganisation.trackedRepos || 0) - 1;
+                });
+            };
+
+            GHToken.query(function(token) {
+                if (token.length > 0) {
+                    loadData();
+                    $scope.hasToken = true;
+                } else {
+                    $scope.hasToken = false;
+                }
+            });
+
+            // ensure that when current project ID changes, we reload
+            $scope.$watch(function() {
+                return $scope.project.id;
+            }, function () {
+                loadData();
+            });
+        }
+    ])
+    .directive('githubConfig', function() {
+        return {
+            controller: 'GithubController',
+            restrict: 'E',
+            templateUrl: STATIC_URL + 'github/github-config.html',
+            scope: {
+                project: '='
+            }
+        };
+    });

--- a/ployst/ui/static/projects/menuProjects.html
+++ b/ployst/ui/static/projects/menuProjects.html
@@ -3,15 +3,15 @@
         <h1>My Projects</h1>
     </header>
     <ul>
-        <li ng-repeat="p in projects" ng-class="{active: p===project}">
-            <a ng-click="selectProject(p)">
+        <li ng-repeat="p in ps.projects" ng-class="{active: p===ps.project}">
+            <a ng-click="ps.selectProject(p)">
                 <i class="fa fa-fw fa-folder"></i> {{ p.name }}
             </a>
         </li>
     </ul>
     <footer>Create a Project:
         <input ng-model="newProject.name" name="name" placeholder="name..."></input>
-        <i ng-click="createProject(newProject)"
+        <i ng-click="ps.createProject(newProject)"
             class="fa fa-fw fa-lg fa-plus-square icon-clickable"
             title="Create Project"></i>
     </footer>

--- a/ployst/ui/static/projects/ployst.projects-test.js
+++ b/ployst/ui/static/projects/ployst.projects-test.js
@@ -18,16 +18,11 @@ describe('test projects controller', function() {
     beforeEach(module('ployst'));
 
     beforeEach(inject(
-        function(_$httpBackend_, $controller, $rootScope, $route, Project, User) {
+        function(_$httpBackend_, $controller, $rootScope, User) {
             $httpBackend = _$httpBackend_;
-            $httpBackend.expectGET('/core/accounts/me')
-                .respond(mockUser);
-            $httpBackend.expectGET('/core/accounts/project')
-                .respond(mockProjects);
-            $httpBackend.expectGET('/static/profile/profile.html')
-                .respond();
+            $httpBackend.expectGET('/core/accounts/me').respond(mockUser);
+            $httpBackend.expectGET('/core/accounts/project').respond(mockProjects);
             User.user = mockUser;
-            _Project = Project;
 
             scope = $rootScope.$new();
             ctrl = $controller(
@@ -42,18 +37,17 @@ describe('test projects controller', function() {
     });
 
     it('scope contains projects, first project is preselected', function() {
-        expect(scope.projects[0].name).toBe('project-one');
-        expect(scope.project).toBe(scope.projects[0]);
-        expect(scope.project.managers).toEqual([mockUser.id]);
+        expect(scope.ps.projects[0].name).toBe('project-one');
+        expect(scope.ps.project).toBe(scope.ps.projects[0]);
+        expect(scope.ps.project.managers).toEqual([mockUser.id]);
     });
 
     it('can delete a project', function() {
-        $httpBackend.expectDELETE('/core/accounts/project/1')
-            .respond();
-        scope.deleteProject(mockProject);
+        $httpBackend.expectDELETE('/core/accounts/project/1').respond();
+        scope.ps.deleteProject(mockProject);
         $httpBackend.flush();
-        expect(scope.projects.length).toBe(0);
-        expect(scope.project).toBe(null);
+        expect(scope.ps.projects.length).toBe(0);
+        expect(scope.ps.project).toBe(null);
     });
 
     it('can create a project, and it becomes the active project', function() {
@@ -66,12 +60,12 @@ describe('test projects controller', function() {
             .respond(mockProject2);
         $httpBackend.expectGET('/core/accounts/project/2')
             .respond(mockProject2);
-        scope.createProject({
+        scope.ps.createProject({
             name: 'project-two'
         });
         $httpBackend.flush();
-        expect(scope.projects.length).toBe(2);
-        expect(scope.project.name).toEqual(mockProject2.name);
+        expect(scope.ps.projects.length).toBe(2);
+        expect(scope.ps.project.name).toEqual(mockProject2.name);
     });
 
 });

--- a/ployst/ui/static/projects/ployst.projects.js
+++ b/ployst/ui/static/projects/ployst.projects.js
@@ -11,35 +11,28 @@ angular.module('ployst.projects', [
             return $resource('/core/accounts/project/:id');
         }
     ])
-    .controller('projects', [
-        '$http', '$scope', 'Project', 'User',
+    .service('ProjectService', [
+        'Project',
 
-        function($http, $scope, Project, User) {
-            $scope.newUser = {};
-            $scope.user = User.user;
-            // prior to project loading, to avoid UI flicker with "no projects"
-            // message:
-            $scope.project = 'unknown';
+        function(Project) {
+            var $this = this;
+            this.project = 'unknown';
+            this.projects = [];
 
-            Project.query(function(projects) {
-                $scope.projects = projects;
-                $scope.setDefaultProject();
-            });
-
-            $scope.setDefaultProject = function() {
+            this.setDefaultProject = function() {
                 // set first project as active
-                if ($scope.projects.length > 0) {
-                    $scope.project = $scope.projects[0];
+                if ($this.projects.length > 0) {
+                    $this.project = $this.projects[0];
                 } else {
-                    $scope.project = null;
+                    $this.project = null;
                 }
             };
 
-            $scope.selectProject = function(project) {
-                $scope.project = project;
+            this.selectProject = function(project) {
+                $this.project = project;
             };
 
-            $scope.createProject = function(newProject) {
+            this.createProject = function(newProject) {
                 var project = new Project({
                     name: newProject.name
                 });
@@ -48,21 +41,35 @@ angular.module('ployst.projects', [
                         id: project.id
                     });
                     // Add to UI
-                    $scope.projects.push(project);
-                    $scope.project = project;
+                    $this.projects.push(project);
+                    $this.project = project;
                     newProject.name = '';
                 });
             };
 
-            $scope.deleteProject = function(project) {
+            this.deleteProject = function(project) {
                 Project.delete({
                     id: project.id
                 }, function() {
-                    // remove from UI once deleted in backend
-                    $scope.projects.splice($scope.projects.indexOf(project), 1);
-                    $scope.setDefaultProject();
+                    // remove from list once deleted in backend
+                    $this.projects.splice($this.projects.indexOf(project), 1);
+                    $this.setDefaultProject();
                 });
             };
+
+            Project.query(function(projects) {
+                $this.projects = projects;
+                $this.setDefaultProject();
+            });
+        }
+    ])
+    .controller('projects', [
+        '$http', '$scope', 'ProjectService', 'User',
+
+        function($http, $scope, ProjectService, User) {
+            $scope.newUser = {};
+            $scope.user = User.user;
+            $scope.ps = ProjectService;
 
             $scope.inviteUser = function(project, user) {
                 // invite user to join project: if email is recognised, add to

--- a/ployst/ui/static/projects/project.html
+++ b/ployst/ui/static/projects/project.html
@@ -2,13 +2,13 @@
 <menu-projects></menu-projects>
 
 <div class="sidebar-rest">
-    <div ng-if="project && (project !== 'unknown')">
+    <div ng-if="ps.project && (ps.project !== 'unknown')">
         <div class="container-fluid">
             <div class="row-fluid">
-                <h2><i class="fa fa-folder"></i> Project {{ project.name }}
+                <h2><i class="fa fa-folder"></i> Project {{ ps.project.name }}
                     <div class="btn-group pull-right">
-                        <button ng-if="project.am_manager"
-                                ng-click="deleteProject(project)"
+                        <button ng-if="ps.project.am_manager"
+                                ng-click="ps.deleteProject(ps.project)"
                                 type="button" class="btn btn-small btn-danger">
                             Delete
                         </button>
@@ -36,20 +36,20 @@
 
 
             <div class="row-fluid" ng-if="tab == 'activity'">
-                <project-activity project="project"></project-activity>
+                <project-activity project="ps.project"></project-activity>
             </div>
 
             <div class="row-fluid" ng-if="tab == 'users'">
-                <project-users></project-users>
+                <project-users project="ps.project"></project-users>
             </div>
 
             <div class="row-fluid" ng-if="tab == 'repos'">
-                <github-config project="project"></github-config>
+                <github-config project="ps.project"></github-config>
             </div>
         </div>
     </div>
 
-    <div ng-if="!project" class="row-fluid">
+    <div ng-if="!ps.project" class="row-fluid">
         <div class="alert alert-info">
             <strong>You have no projects yet.</strong>
             Why don't you go ahead and create one?

--- a/ployst/ui/static/projects/projectUsers.html
+++ b/ployst/ui/static/projects/projectUsers.html
@@ -1,15 +1,15 @@
 <ul class="fa-ul">
-    <li ng-repeat="user in project.users">
+    <li ng-repeat="user in ps.project.users">
         <i ng-if="user.manager"
             class="fa fa-fw fa-star" title="manager"></i>
         <i ng-if="!user.manager"
             class="fa fa-fw"></i>
         <span>{{ user.user.username }}</span>
     </li>
-    <li ng-if="project.am_manager">
-        <h5>Invite a user to join {{ project.name }}:</h5>
+    <li ng-if="ps.project.am_manager">
+        <h5>Invite a user to join {{ ps.project.name }}:</h5>
         <input ng-model="newUser.email" name="email" placeholder="email..."></input>
-        <i ng-click="inviteUser(project, newUser)"
+        <i ng-click="inviteUser(ps.project, newUser)"
             class="fa fa-fw fa-lg fa-plus-square icon-clickable"
             title="Invite a User"></i>
     </li>

--- a/ployst/ui/static/repos/ployst.repos.js
+++ b/ployst/ui/static/repos/ployst.repos.js
@@ -34,15 +34,24 @@ angular.module('ployst.repos', [
             $scope.repos = [];
             $scope.branches = null;
 
-            Repos.query({'project': $scope.project.id}, function(repos) {
-                $scope.repos = repos;
-                $scope.branches = [];
-                angular.forEach(repos, function(repo) {
-                    angular.forEach(repo.branches, function(branch) {
-                        branch.repo = repo.owner + '/' + repo.name;
-                        $scope.branches.push(branch);
+            var loadData = function() {
+                Repos.query({'project': $scope.project.id}, function (repos) {
+                    $scope.repos = repos;
+                    $scope.branches = [];
+                    angular.forEach(repos, function (repo) {
+                        angular.forEach(repo.branches, function (branch) {
+                            branch.repo = repo.owner + '/' + repo.name;
+                            $scope.branches.push(branch);
+                        });
                     });
                 });
+            };
+
+            // ensure that when current project ID changes, we reload
+            $scope.$watch(function() {
+                return $scope.project.id;
+            }, function () {
+                loadData();
             });
         }
     ])


### PR DESCRIPTION
Turns out one of angularJS's best practices is to put more code in services and have very thin controllers. Apparently the best approach is to have directives with isolate scopes (you may have seen me add `scope` in directives at some point), and let those rely on services for shared ...erm... services.

This is one step into that direction, but there will be more, as I figure out _the ways of the angular_.

Most of this PR is just shuffling lines of code.

It will all make sense one day. I promise to write a small doc describing the guidelines behind the structure of angular code.
