### PR TITLE
Generalise hook handling, in preparation to handle PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tags
 .ropeproject/
 /assets/lib
 /node_modules/
+github-hook*.json
 
 # Editors and IDEs
 .project
@@ -22,9 +23,9 @@ tags
 /docs/build
 /ployst.egg-info
 /static
+/.tox/
 
 # Some OSX specific thing
 *.DS_Store
-/.tox/
 
 ployst/github/test/data/

--- a/ployst/github/github_client.py
+++ b/ployst/github/github_client.py
@@ -1,5 +1,4 @@
 from github3 import login
-import hmac
 import hashlib
 
 from . import client as ployst_core
@@ -15,11 +14,6 @@ def get_secret(org, repo):
     """
     return (hashlib.md5(org + repo + settings.GITHUB_HOOK_SECRET_SALT)
             .hexdigest())
-
-
-def compute_github_signature(body, org, repo):
-    secret = get_secret(org, repo)
-    return hmac.new(secret, body, hashlib.sha1).hexdigest()
 
 
 class GithubClient(object):

--- a/ployst/github/hooker.py
+++ b/ployst/github/hooker.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+import hashlib
+import hmac
+import json
+
+
+DEBUG = True
+
+
+class GithubHookException(Exception):
+    pass
+
+
+def compute_github_signature(body, secret):
+    return hmac.new(secret, body, hashlib.sha1).hexdigest()
+
+
+class GithubHookHandler(object):
+    """
+    A general purpose-class to help build github hook handlers.
+
+    See https://developer.github.com/webhooks/ for Github's webhook spec.
+
+    NOTE: This module may be spin-off into a separate library.
+    """
+
+    @staticmethod
+    def get_org_repo(request):
+        try:
+            payload = json.loads(request.body)
+            url = payload['repository']['url']
+            org, repo = url.split('/')[-2:]
+            return org, repo
+        except ValueError:
+            raise GithubHookException("Invalid payload")
+
+    def __init__(self, secret, request):
+        hub_sig = request.META['HTTP_X_HUB_SIGNATURE']
+        payload = request.body
+
+        if not self.validate_hook_post(payload, secret, hub_sig):
+            raise GithubHookException("Incorrect signature")
+
+        self.payload = json.loads(request.body)
+        self.event = request.META['HTTP_X_GITHUB_EVENT']
+
+        if DEBUG:
+            filename = 'github-hook-{}.json'.format(datetime.now().isoformat())
+            with open(filename, 'w') as f:
+                f.write(request.body)
+
+    @property
+    def org_repo(self):
+        url = self.payload['repository']['url']
+        org, repo = url.split('/')[-2:]
+        return org, repo
+
+    def validate_hook_post(self, body, secret, hub_signature):
+        """
+        Check that the post is legitimate.
+
+        A post is considered valid if the HMAC digest of the body equals the
+        header given in `X-Hub-Signature`.
+
+        See https://developer.github.com/v3/repos/hooks/#example
+        """
+        computed = compute_github_signature(body, secret)
+        sent_sig = hub_signature.split('sha1=')[-1]
+        return computed == sent_sig
+
+    def route(self):
+        """
+        Routes to the correct method based on github event.
+
+        It will call a method named `on_<event>` and provide the specific
+        part of the payload that corresponds to the event name.
+
+        See https://developer.github.com/v3/activity/events/types/ for details.
+
+        """
+        # Ensure self.org and self.repo are initialised before the handler
+        # method is called
+        self.org, self.repo = self.org_repo
+
+        handler_name = 'on_{}'.format(self.event)
+        if hasattr(self, handler_name):
+            getattr(self, handler_name)(self.payload)

--- a/ployst/github/test/test_end_to_end.py
+++ b/ployst/github/test/test_end_to_end.py
@@ -15,7 +15,7 @@ class TestEndToEnd(TestCase):
     def setUp(self):
         ensure_dummy_clone_available()
 
-    @patch(__name__ + '.tasks.hierarchy.client', MockClient())
+    @patch('ployst.github.tasks.hierarchy.client', MockClient())
     @override_settings(GITHUB_REPOSITORY_LOCATION=DUMMY_CODE_DIR)
     @override_settings(GITHUB_CALCULATE_HIERARCHIES_ON_HOOK=True)
     def test_receive_hook_end_to_end(self):
@@ -34,7 +34,10 @@ class TestEndToEnd(TestCase):
             reverse('github:hook'),
             data=data,
             content_type='application/json',
-            **{'HTTP_X_HUB_SIGNATURE': hub_sig}
+            **{
+                'HTTP_X_HUB_SIGNATURE': hub_sig,
+                'HTTP_X_GITHUB_EVENT': 'push',
+            }
         )
 
         self.assertEquals(response.status_code, 200)


### PR DESCRIPTION
Part of task https://txels.tpondemand.com/entity/365

This is an initial refactor to generalise how we handle github hooks. I'd like to actually extract the module `hooker.py` into a separate installable library e.g. "github-hooker".

I haven't written specific unit tests for the new module, but all existing tests pass, and the github_poke command works. If we decide to pull this out as a library, I'll move/rewrite tests accordingly.
