### PR TITLE
Add event to hook collected JSON file for better spotting

### DIFF
--- a/ployst/github/hooker.py
+++ b/ployst/github/hooker.py
@@ -45,7 +45,9 @@ class GithubHookHandler(object):
         self.event = request.META['HTTP_X_GITHUB_EVENT']
 
         if DEBUG:
-            filename = 'github-hook-{}.json'.format(datetime.now().isoformat())
+            filename = 'github-hook-{}-{}.json'.format(
+                datetime.now().isoformat(), self.event
+            )
             with open(filename, 'w') as f:
                 f.write(request.body)
 

--- a/ployst/github/views/hook.py
+++ b/ployst/github/views/hook.py
@@ -27,7 +27,7 @@ class PloystGithubHookHandler(GithubHookHandler):
     """
     Custom Github hook handler for ployst.
 
-    Add an on_<event> method for each new event you want to hndle
+    Add an on_<event> method for each new event you want to handle.
 
     """
     def on_push(self, payload):


### PR DESCRIPTION
This way we can see what github events the payload is for, with the JSON file name.
