### PR TITLE
Ensure latest ployst is runnable on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn ployst.wsgi
+web: gunicorn --workers 4 -k eventlet ployst.wsgi

--- a/docs/heroku-bootstrap.md
+++ b/docs/heroku-bootstrap.md
@@ -1,0 +1,31 @@
+# Bootstrapping ployst in Heroku
+
+## In Github
+
+Create an application entry in Github.
+
+    https://github.com/settings/applications/
+
+Callback URL: http://ployst.com/github/oauth-confirmed/
+
+Copy client ID and client secret to use as `GITHUB_CLIENT_ID` and
+`GITHUB_CLIENT_SECRET`.
+
+## In ployst
+
+Go to admin and create an API token, label github.
+Copy the token to use as `GITHUB_CORE_API_TOKEN`
+
+## In Heroku
+
+Go to ployst settings page:
+
+    https://dashboard.heroku.com/apps/ployst/settings
+
+Reveal config vars. Add/set values for the following:
+
+    GITHUB_CORE_API_TOKEN
+    GITHUB_CLIENT_ID
+    GITHUB_CLIENT_SECRET
+
+All these can also be set via `heroku config`.

--- a/ployst/celery.py
+++ b/ployst/celery.py
@@ -7,7 +7,7 @@ from celery import Celery
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ployst.settings.dev')
 
-from django.conf import settings
+from django.conf import settings  # noqa
 
 app = Celery('ployst')
 

--- a/ployst/settings/heroku.py
+++ b/ployst/settings/heroku.py
@@ -1,4 +1,7 @@
+from os import getenv
+
 from .base import *  # noqa
+
 
 # Parse database configuration from $DATABASE_URL
 import dj_database_url
@@ -17,3 +20,13 @@ ALLOWED_HOSTS = ['*']
 # http://django-storages.readthedocs.org/en/latest/backends/amazon-S3.html
 
 DEBUG = True
+
+# Heroku sets the PORT environment var. It changes on each restart.
+CORE_API_ADDRESS = "http://localhost:{}/".format(getenv('PORT', 8000))
+
+# The API token created in admin for 'github'
+GITHUB_CORE_API_TOKEN = getenv('GITHUB_CORE_API_TOKEN')
+
+# The application OAUTH settings from github.com/ applications
+GITHUB_CLIENT_ID = getenv('GITHUB_CLIENT_ID')
+GITHUB_CLIENT_SECRET = getenv('GITHUB_CLIENT_SECRET')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gunicorn==18.0
 dj-database-url==0.2.2
 dj-static==0.0.6
 psycopg2==2.6
+eventlet==0.17.1

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,6 @@
-django==1.7.3
+django==1.7.7
 django-appconf==0.6              # provides graceful configuration of apps
-django-compressor==1.4
+django-compressor==1.4           # static asset compression
 django-crispy-forms==1.4.0       # better control over form rendering
 django-filter==0.7               # provides generic filtering in API
 djangorestframework==3.0.3       # Rest API
@@ -8,12 +8,12 @@ django-registration-redux==1.1   # user accounts and registration
 drf-extensions==0.2.5            # DRF enhancements, including nested routers
 
 # API client requirements
-apitopy==0.3.0
-requests==2.3.0
+apitopy==0.3.0                   # pythonic HTTP API clients
+requests==2.3.0                  # HTTP client library
 
 
 # Git provider requirements
 GitPython==0.3.2.RC1             # access local git repositories
 github3.py==0.8.2                # access github repositories
 
-celery==3.1.11
+celery==3.1.11                   # asynchronous task execution


### PR DESCRIPTION
The github integration didn't work, as the GH provider needed to talk to core and find out what port it was running on.
